### PR TITLE
Move to "coverage" method for contour dissolving

### DIFF
--- a/src/rastr/raster.py
+++ b/src/rastr/raster.py
@@ -968,7 +968,7 @@ class Raster(BaseModel):
         )
 
         # Dissolve contours by level to merge all contour lines of the same level
-        return contour_gdf.dissolve(by="level", as_index=False)
+        return contour_gdf.dissolve(by="level", method="coverage", as_index=False)
 
     def blur(self, sigma: float, *, preserve_nan: bool = True) -> Self:
         """Apply a Gaussian blur to the raster data.


### PR DESCRIPTION
Using "coverage":

```
pyinstrument ........................................
.
.  Block at c:\Users\namc\Repositories\rastr\src\scripts\benchmark_contour.py:8
.
.  64.853 <module>  benchmark_contour.py:1
.  └─ 64.847 Raster.contour  rastr\raster.py:902
.     ├─ 60.270 catmull_rom_smooth  rastr\gis\smooth.py:24
.     │  ├─ 57.478 _catmull_rom  rastr\gis\smooth.py:51
.     │  │  ├─ 50.150 _recursive_eval  rastr\gis\smooth.py:94
.     │  │  │  ├─ 41.109 [self]  rastr\gis\smooth.py
.     │  │  │  ├─ 4.705 array  <built-in>
.     │  │  │  ├─ 2.213 list.append  <built-in>
.     │  │  │  ├─ 1.235 max  <built-in>
.     │  │  │  └─ 0.888 ndarray.copy  <built-in>
.     │  │  ├─ 2.381 norm  numpy\linalg\_linalg.py:2622
.     │  │  ├─ 2.357 [self]  rastr\gis\smooth.py
.     │  │  └─ 2.184 linspace  numpy\_core\function_base.py:26
.     │  └─ 2.683 type.__new__  shapely\geometry\linestring.py:40
.     │     └─ 1.588 _coords  shapely\geometry\linestring.py:63
.     ├─ 2.486 GeoDataFrame.dissolve  geopandas\geodataframe.py:2128
.     │     [11 frames hidden]  pandas, geopandas, shapely
.     └─ 1.194 find_contours  skimage\measure\_find_contours.py:10
.
.....................................................
```

Using the previous approach using default of method="unary"

```
pyinstrument ........................................
.
.  Block at c:\Users\namc\Repositories\rastr\src\scripts\benchmark_contour.py:8
.
.  57.585 <module>  benchmark_contour.py:1
.  └─ 57.578 Raster.contour  rastr\raster.py:902
.     ├─ 55.428 catmull_rom_smooth  rastr\gis\smooth.py:24
.     │  ├─ 52.806 _catmull_rom  rastr\gis\smooth.py:51
.     │  │  ├─ 46.245 _recursive_eval  rastr\gis\smooth.py:94
.     │  │  │  ├─ 37.788 [self]  rastr\gis\smooth.py
.     │  │  │  ├─ 4.396 array  <built-in>
.     │  │  │  ├─ 2.081 list.append  <built-in>
.     │  │  │  ├─ 1.123 max  <built-in>
.     │  │  │  └─ 0.857 ndarray.copy  <built-in>
.     │  │  ├─ 2.136 norm  numpy\linalg\_linalg.py:2622
.     │  │  ├─ 2.112 [self]  rastr\gis\smooth.py
.     │  │  └─ 1.835 linspace  numpy\_core\function_base.py:26
.     │  └─ 2.502 type.__new__  shapely\geometry\linestring.py:40
.     │     └─ 1.533 _coords  shapely\geometry\linestring.py:63
.     └─ 1.191 find_contours  skimage\measure\_find_contours.py:10
.
.....................................................
```

So actually the previous approach was more optimized, despite what the docs said.