### PR TITLE
Restore support to `tuple`-like crop arguments

### DIFF
--- a/src/rastr/raster.py
+++ b/src/rastr/raster.py
@@ -1290,7 +1290,7 @@ class Raster(BaseModel):
 
     def crop(
         self,
-        bounds: ArrayLike,
+        bounds: tuple[float, float, float, float] | Bounds | ArrayLike,
         *,
         strategy: Literal["underflow", "overflow"] = "underflow",
     ) -> Self:


### PR DESCRIPTION
Reverts this change from tonkintaylor/rastr#363