### PR TITLE
Adjust catmull_rom_smooth to accept BaseGeometry

### DIFF
--- a/src/rastr/gis/smooth.py
+++ b/src/rastr/gis/smooth.py
@@ -5,7 +5,7 @@ Fork + Port of <https://github.com/philipschall/shapelysmooth> (Public domain)
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
@@ -14,15 +14,16 @@ from typing_extensions import assert_never
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
-
-T = TypeVar("T", bound=LineString | Polygon)
+    from shapely.geometry.base import BaseGeometry
 
 
 class InputeTypeError(TypeError):
     """Raised when the input geometry is of the incorrect type."""
 
 
-def catmull_rom_smooth(geometry: T, alpha: float = 0.5, subdivs: int = 10) -> T:
+def catmull_rom_smooth(
+    geometry: BaseGeometry, alpha: float = 0.5, subdivs: int = 10
+) -> LineString | Polygon:
     """Polyline smoothing using Catmull-Rom splines.
 
     Args:
@@ -36,6 +37,9 @@ def catmull_rom_smooth(geometry: T, alpha: float = 0.5, subdivs: int = 10) -> T:
 
     Returns: The smoothed geometry.
     """
+    if not isinstance(geometry, (LineString, Polygon)):
+        msg = "Only LineString and Polygon geometries are supported."
+        raise NotImplementedError(msg)
     coords, interior_coords = _get_coords(geometry)
     coords_smoothed = _catmull_rom(coords, alpha=alpha, subdivs=subdivs)
     if isinstance(geometry, LineString):

--- a/tests/rastr/gis/test_smooth.py
+++ b/tests/rastr/gis/test_smooth.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from shapely.geometry import LineString, Polygon
+from shapely.geometry import LineString, Point, Polygon
 
 from rastr.gis.smooth import _recursive_eval, catmull_rom_smooth
 
@@ -51,6 +51,14 @@ class TestCatmullRomSmooth:
         assert result.interiors[0].coords[0] == pytest.approx(
             result.interiors[0].coords[-1]
         )
+
+    def test_invalid_geometry(self):
+        # Arrange
+        point = Point(0, 0)
+        # Act & Assert
+        msg = "Only LineString and Polygon geometries are supported"
+        with pytest.raises(NotImplementedError, match=msg):
+            catmull_rom_smooth(point, alpha=0.5, subdivs=5)
 
     @pytest.mark.parametrize("alpha", [0.0, 0.5, 1.0])
     @pytest.mark.parametrize("subdivs", [2, 5, 10])


### PR DESCRIPTION
Raises NotImplementedError for geometries that are not Linestring or Polygon.