### PR TITLE
ci: reduce runner costs — Linux-first matrix with targeted cross-platform spot-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.10", "3.14"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         dependencies: ["lockfile"]
         sonarqube: ["false"]
         include:
@@ -94,6 +94,17 @@ jobs:
           - dependencies: "max"
             python_version: "3.14"
             os: "ubuntu-latest"
+            checks: "false"
+          # Cross-platform spot-checks on latest Python only (cost-reduced from full matrix)
+          - python_version: "3.14"
+            os: "windows-latest"
+            dependencies: "lockfile"
+            sonarqube: "false"
+            checks: "false"
+          - python_version: "3.14"
+            os: "macos-latest"
+            dependencies: "lockfile"
+            sonarqube: "false"
             checks: "false"
 
   code-analysis:
@@ -138,3 +149,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+


### PR DESCRIPTION
## Context — GitHub Actions cost reduction

The `tonkintaylor` organisation is currently spending **\.46 over** its included Actions minutes (as of April 2026). An audit of all 37 org repositories identified this repo as the **highest-volume** cost contributor, with 93 workflow runs recorded since January 2026.

## What the current setup costs

The CI matrix runs **2 Python versions × 3 operating systems = 6 cross-platform jobs** per push, plus 5 ubuntu-only include jobs — **~11 jobs total per trigger**.

GitHub charges hosted runner minutes at:

| Runner | Multiplier |
|---|---|
| `ubuntu-latest` | 1× |
| `windows-latest` | **2×** |
| `macos-latest` | **10×** |

With 93 runs, 2 macOS jobs per trigger at ~3 min each = **~5,580 Linux-equivalent minutes** for macOS alone.

## What this changes

| | Before | After |
|---|---|---|
| Main matrix | `["3.10","3.14"]` × 3 OS | `["3.10","3.14"]` × Linux only |
| Cross-platform | Both Python versions on Win + macOS | Spot-check on 3.14 only: 1 Windows + 1 macOS |
| Ubuntu includes (3.11–3.13, min, max) | Unchanged | Unchanged |
| **Jobs/trigger** | **~11** | **~9** |

The spot-check jobs set `checks: "false"` to skip pre-commit/pyright on Windows/macOS (those checks are already verified on Linux and not meaningful cross-platform).

## Why this is safe

`rastr` is a published PyPI library — cross-platform validation is genuinely valuable. This change preserves it: a platform-specific packaging, import, or runtime bug in Python 3.14 will still be caught by the spot-checks. Full Python version coverage (3.10–3.14) continues on Linux. The old approach of testing **every** Python version on **every** OS provides diminishing returns in exchange for significant cost.

## No functional changes

No source code, tests, or configuration is modified. This is a CI runner change only.