### PR TITLE
fix: construct resample transform from exact target cell size

### DIFF
--- a/src/rastr/raster.py
+++ b/src/rastr/raster.py
@@ -22,6 +22,7 @@ import rasterio.features
 import rasterio.plot
 import rasterio.sample
 import rasterio.transform
+from affine import Affine
 from pydantic import BaseModel, InstanceOf, field_validator
 from pyproj import Transformer
 from pyproj.crs.crs import CRS
@@ -41,7 +42,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import geopandas as gpd
-    from affine import Affine
     from branca.colormap import LinearColormap as BrancaLinearColormap
     from folium import Map
     from matplotlib.axes import Axes
@@ -1929,12 +1929,15 @@ class Raster(BaseModel):
                 resampling=Resampling.bilinear,
             )
 
-            # Create new RasterMeta with updated transform
+            # Create new RasterMeta with the exact requested cell size
             new_raster_meta = RasterMeta(
-                transform=dataset.transform
-                * dataset.transform.scale(
-                    (dataset.width / new_width),
-                    (dataset.height / new_height),
+                transform=Affine(
+                    target_cell_width,
+                    dataset.transform.b,
+                    dataset.transform.c,
+                    dataset.transform.d,
+                    -target_cell_height,
+                    dataset.transform.f,
                 ),
                 crs=self.raster_meta.crs,
             )

--- a/tests/rastr/test_raster.py
+++ b/tests/rastr/test_raster.py
@@ -4630,6 +4630,21 @@ class TestResample:
         result = float64_raster.resample(cell_size=0.5)
         assert result.arr.dtype == np.float64
 
+    def test_non_multiple_dimensions_produce_exact_cell_size(self):
+        """Regression: non-multiple dimensions must not drift cell size."""
+        arr = np.random.default_rng(42).random((101, 99)).astype(np.float32)
+        meta = RasterMeta(
+            transform=Affine(0.5, 0, 100.0, 0, -0.5, 200.0),
+            crs=CRS.from_epsg(2193),
+        )
+        raster = Raster(arr=arr, raster_meta=meta)
+
+        resampled = raster.resample(2.0)
+
+        assert resampled.raster_meta.cell_size == (2.0, 2.0)
+        assert resampled.raster_meta.has_square_cells
+        assert resampled.raster_meta.square_cell_size == 2.0
+
 
 class TestReplacePolygon:
     def test_single_polygon_full_extent_of_raster(self, example_raster: Raster):


### PR DESCRIPTION
Raster.resample() now produces output cells with the exact requested cell size, fixing drift that caused downstream NonSquareCellsError.

Background:
- The original implementation (63355c4, 2025-08-13) computed the output transform via dataset.transform.scale(width/new_width, height/new_height), which introduces rounding error when np.ceil rounds the array dimensions. This was masked by a stored cell_size field on RasterMeta that acted as the source of truth regardless of what the transform said.
- In aa699db (2026-02-18), cell_size was refactored from a stored field to a derived property (abs(transform.a)), but the transform computation was left unchanged. The compensating mechanism was removed without fixing the underlying calculation, exposing the drift.
- Existing tests never caught this because their fixtures use dimensions (4x4, 2x2) and ratios (x2, /2) where ceil produces exact integers.

Fix: construct the Affine transform directly from the target cell size, preserving the original origin. The ceil-rounded array dimensions still ensure full extent coverage, but the metadata is now truthful.

Closes #438