### PR TITLE
feat: add origin property and set_origin() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ from rastr import Raster
 - [`Raster.bounds`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.bounds) - bounding box as `(xmin, ymin, xmax, ymax)`.
 - [`Raster.cell_size`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.cell_size) - cell size.
 - [`Raster.crs`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.crs) - coordinate reference system.
+- [`Raster.origin`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.origin) - grid origin (x, y) of the first pixel corner.
 - [`Raster.shape`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.shape) - raster shape (rows, columns).
 - [`Raster.transform`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.transform) - affine transform.
 - [`Raster.sample(xy)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.sample) - sample raster values at given coordinates.
@@ -109,6 +110,7 @@ from rastr import Raster
 - [`Raster.crop(bounds)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.crop) - remove cells outside given bounds.
 - [`Raster.pad(width)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.pad) - add NaN border around raster.
 - [`Raster.resample(cell_size)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.resample) - resample raster to a new cell size.
+- [`Raster.set_origin(x, y)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.set_origin) - set the transform origin without modifying pixel data.
 - [`Raster.taper_border(width)`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.taper_border) - gradually reduce values to zero at the border.
 - [`Raster.gdf()`](https://rastr.readthedocs.io/en/stable/autoapi/rastr/raster/#rastr.raster.Raster.gdf) - Vectorize to a GeoDataFrame of cell polygons and values.
 

--- a/docs/specs/2025-05-20-set-origin-design.md
+++ b/docs/specs/2025-05-20-set-origin-design.md
@@ -1,0 +1,107 @@
+# Spec: `set_origin` — Relocate Raster Grid Origin
+
+**Date:** 2025-05-20
+**Issue:** #442
+**Branch:** `442-feature-request-shift_bounds-translate_bounds-method-for-longitude-wrapping`
+
+## Motivation
+
+When working with ShakeMap rasters for events near the antimeridian (e.g. New Zealand), some source rasters arrive with non-standard longitude conventions where longitudes are stored as negative values that exceed -180° (e.g. bounds from -200° to -170° instead of 160° to 190°).
+
+This causes spatial operations like `to_bounds()` to produce all-NaN output because there's no overlap between the raster's stored coordinates and the target bounds in standard EPSG:4326.
+
+Currently the only workaround is manually reconstructing the affine transform with an offset applied to the origin coordinate, or rebuilding the Raster with adjusted metadata.
+
+## Design
+
+### 1. Read-only property: `Raster.origin`
+
+```python
+@property
+def origin(self) -> tuple[float, float]:
+    """The grid origin (x, y) — the corner of the first pixel.
+
+    This is the translation component (c, f) of the affine transform.
+    For north-up rasters this corresponds to (xmin, ymax); for south-up
+    rasters it corresponds to (xmin, ymin).
+    """
+    return (self.transform.c, self.transform.f)
+```
+
+### 2. Property setter (mutable, for notebooks/interactive use)
+
+```python
+@origin.setter
+def origin(self, value: tuple[float, float]) -> None:
+    """Set the grid origin via the transform."""
+    x, y = value
+    t = self.transform
+    self.transform = Affine(t.a, t.b, x, t.d, t.e, y)
+```
+
+### 3. Immutable method: `Raster.set_origin()`
+
+```python
+def set_origin(self, *, x: float | None = None, y: float | None = None) -> Self:
+    """Set the transform origin without modifying pixel data.
+
+    The origin is the corner of the first pixel in the raster grid —
+    the translation component (c, f) of the affine transform. For
+    north-up rasters this corresponds to (xmin, ymax); for south-up
+    rasters it corresponds to (xmin, ymin).
+
+    Unspecified axes retain their current value. If neither axis is
+    provided, returns an unchanged copy.
+
+    Args:
+        x: New x-coordinate of the grid origin. If None, keeps current.
+        y: New y-coordinate of the grid origin. If None, keeps current.
+
+    Returns:
+        A new Raster with the updated transform origin and unchanged array data.
+
+    Example:
+        Normalize a raster with non-standard longitude (e.g., -200° to -170°)
+        to standard EPSG:4326 range::
+
+            raster = raster.set_origin(x=raster.origin[0] + 360)
+    """
+```
+
+## Interface Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Keyword-only args on `set_origin()` | Passing one axis alone is common; `set_origin(160)` would be ambiguous about which axis |
+| `None` = keep current | Allows shifting just x or just y without computing the other |
+| No-op when both are None | Not an error — returns an unchanged copy |
+| Both property setter and method | Setter for interactive/notebook mutation; method for immutable pipeline use. Mirrors the existing `crs`/`set_crs()` pattern |
+| No `set_transform()` method | The `transform` property setter already covers arbitrary replacement. A method would just add `allow_override` ceremony with no value since a transform is always present |
+| No delta/shift method | `raster.origin[0] + 360` is simple enough. Can revisit if arithmetic at call sites becomes tedious |
+| Docstring acknowledges both axis conventions | "Corner of the first pixel" is unambiguous regardless of north-up vs south-up |
+
+## Placement
+
+- `origin` property + setter: next to the existing `transform` property/setter block (~line 136 in `raster.py`)
+- `set_origin()` method: next to `set_crs()` (~line 427 in `raster.py`)
+
+## Usage Example
+
+```python
+from rastr import Raster
+
+raster = Raster.read_file("shakemap.tif")
+
+# Raster has non-standard longitude: bounds are (-200, -50, -170, -30)
+if raster.bounds.xmin < -180:
+    raster = raster.set_origin(x=raster.origin[0] + 360)
+
+# Now bounds are (160, -50, 190, -30) — standard range
+result = raster.to_bounds(target_bounds)
+```
+
+## Not Included
+
+- Automatic longitude detection/normalization (caller decides when and how much to shift)
+- Reprojection or pixel resampling (this is metadata-only)
+- Validation that the new origin is "sensible" (the user knows their data)

--- a/docs/specs/2025-05-20-set-origin-design.md
+++ b/docs/specs/2025-05-20-set-origin-design.md
@@ -6,11 +6,21 @@
 
 ## Motivation
 
-When working with ShakeMap rasters for events near the antimeridian (e.g. New Zealand), some source rasters arrive with non-standard longitude conventions where longitudes are stored as negative values that exceed -180° (e.g. bounds from -200° to -170° instead of 160° to 190°).
+Some upstream data sources produce raster files with non-standard longitude
+conventions. For example, certain ShakeMap TIFs for events near the
+antimeridian (e.g. New Zealand) store longitudes as negative values that
+exceed -180° (e.g. bounds from -200° to -170° instead of 160° to 190°).
 
-This causes spatial operations like `to_bounds()` to produce all-NaN output because there's no overlap between the raster's stored coordinates and the target bounds in standard EPSG:4326.
+This is a data-quality issue in the source files, not a bug in rastr. However,
+when such a raster is loaded, spatial operations like `to_bounds()` produce
+all-NaN output because the stored coordinates have no overlap with target
+bounds expressed in standard EPSG:4326.
 
-Currently the only workaround is manually reconstructing the affine transform with an offset applied to the origin coordinate, or rebuilding the Raster with adjusted metadata.
+The existing workaround — manually reconstructing the affine transform or
+rebuilding the Raster with adjusted metadata — works but is verbose and
+non-obvious. The purpose of this feature is not to fix the upstream data
+problem, but to provide a clean, readable API for callers who need to
+normalize such rasters before performing spatial operations.
 
 ## Design
 
@@ -100,8 +110,10 @@ if raster.bounds.xmin < -180:
 result = raster.to_bounds(target_bounds)
 ```
 
-## Not Included
+## Deliberately Excluded
 
-- Automatic longitude detection/normalization (caller decides when and how much to shift)
-- Reprojection or pixel resampling (this is metadata-only)
-- Validation that the new origin is "sensible" (the user knows their data)
+The following were considered and rejected as contrary to the design intent:
+
+- **Automatic longitude detection/normalization** — Baking a detection heuristic into the library is premature. Different datasets use different conventions (0–360, -180–180, etc.) and the "correct" normalization depends on the caller's target coordinate space. The caller decides when and how much to shift.
+- **Reprojection or pixel resampling** — This feature is metadata-only by design. It adjusts where the grid sits in coordinate space without touching pixel values. Reprojection is a fundamentally different operation.
+- **Validation that the new origin is "sensible"** — The user knows their data. Adding bounds-checking would prevent legitimate use cases (e.g. rasters in projected CRS with large coordinate values) without catching the errors it aims to prevent.

--- a/src/rastr/raster.py
+++ b/src/rastr/raster.py
@@ -139,6 +139,23 @@ class Raster(BaseModel):
         self.meta.transform = value
 
     @property
+    def origin(self) -> tuple[float, float]:
+        """The grid origin (x, y) — the corner of the first pixel.
+
+        This is the translation component (c, f) of the affine transform.
+        For north-up rasters this corresponds to (xmin, ymax); for south-up
+        rasters it corresponds to (xmin, ymin).
+        """
+        return (self.transform.c, self.transform.f)
+
+    @origin.setter
+    def origin(self, value: tuple[float, float]) -> None:
+        """Set the grid origin via the transform."""
+        x, y = value
+        t = self.transform
+        self.transform = Affine(t.a, t.b, x, t.d, t.e, y)
+
+    @property
     def cell_size(self) -> tuple[float, float]:
         """Convenience property to access the cell size via meta."""
         return self.meta.cell_size
@@ -462,6 +479,40 @@ class Raster(BaseModel):
         new_meta = RasterMeta(
             crs=crs_obj,
             transform=self.raster_meta.transform,
+        )
+        return self.__class__(arr=self.arr, raster_meta=new_meta)
+
+    def set_origin(self, *, x: float | None = None, y: float | None = None) -> Self:
+        """Set the transform origin without modifying pixel data.
+
+        The origin is the corner of the first pixel in the raster grid —
+        the translation component (c, f) of the affine transform. For
+        north-up rasters this corresponds to (xmin, ymax); for south-up
+        rasters it corresponds to (xmin, ymin).
+
+        Unspecified axes retain their current value. If neither axis is
+        provided, returns an unchanged copy.
+
+        Args:
+            x: New x-coordinate of the grid origin. If None, keeps current.
+            y: New y-coordinate of the grid origin. If None, keeps current.
+
+        Returns:
+            A new Raster with the updated transform origin and unchanged array data.
+
+        Example:
+            Normalize a raster with non-standard longitude (e.g., -200° to -170°)
+            to standard EPSG:4326 range::
+
+                raster = raster.set_origin(x=raster.origin[0] + 360)
+        """
+        t = self.raster_meta.transform
+        new_x = x if x is not None else t.c
+        new_y = y if y is not None else t.f
+        new_transform = Affine(t.a, t.b, new_x, t.d, t.e, new_y)
+        new_meta = RasterMeta(
+            crs=self.raster_meta.crs,
+            transform=new_transform,
         )
         return self.__class__(arr=self.arr, raster_meta=new_meta)
 

--- a/tests/rastr/test_raster.py
+++ b/tests/rastr/test_raster.py
@@ -322,6 +322,52 @@ class TestRaster:
             assert example_raster.raster_meta.transform == new_transform
             assert example_raster.transform != original_transform
 
+    class TestOrigin:
+        def test_origin_getter(self, example_raster: Raster):
+            # Act
+            origin = example_raster.origin
+
+            # Assert
+            assert origin == (example_raster.transform.c, example_raster.transform.f)
+
+        def test_origin_getter_with_offset(self):
+            # Arrange
+            meta = RasterMeta(
+                crs=CRS.from_epsg(4326),
+                transform=Affine(0.1, 0.0, 160.0, 0.0, -0.1, -30.0),
+            )
+            raster = Raster(arr=np.ones((10, 10)), raster_meta=meta)
+
+            # Act
+            origin = raster.origin
+
+            # Assert
+            assert origin == (160.0, -30.0)
+
+        def test_origin_setter(self, example_raster: Raster):
+            # Arrange
+            new_origin = (100.0, 200.0)
+
+            # Act
+            example_raster.origin = new_origin
+
+            # Assert
+            assert example_raster.origin == new_origin
+            assert example_raster.transform.c == 100.0
+            assert example_raster.transform.f == 200.0
+
+        def test_origin_setter_preserves_scale(self, example_raster: Raster):
+            # Arrange
+            original_a = example_raster.transform.a
+            original_e = example_raster.transform.e
+
+            # Act
+            example_raster.origin = (50.0, 60.0)
+
+            # Assert
+            assert example_raster.transform.a == original_a
+            assert example_raster.transform.e == original_e
+
     class TestCellSize:
         def test_cell_size_getter(self, example_raster: Raster):
             # Act
@@ -1481,6 +1527,71 @@ class TestRaster:
 
             # Assert
             assert result.crs.to_epsg() == example_raster.crs.to_epsg()
+
+    class TestSetOrigin:
+        def test_set_x(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin(x=100.0)
+
+            # Assert
+            assert result.origin == (100.0, example_raster.origin[1])
+            assert np.array_equal(result.arr, example_raster.arr)
+            assert result.crs == example_raster.crs
+
+        def test_set_y(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin(y=200.0)
+
+            # Assert
+            assert result.origin == (example_raster.origin[0], 200.0)
+            assert np.array_equal(result.arr, example_raster.arr)
+
+        def test_set_both(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin(x=50.0, y=60.0)
+
+            # Assert
+            assert result.origin == (50.0, 60.0)
+            assert np.array_equal(result.arr, example_raster.arr)
+
+        def test_no_op_when_neither_provided(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin()
+
+            # Assert
+            assert result.origin == example_raster.origin
+            assert result is not example_raster
+
+        def test_returns_new_instance(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin(x=100.0)
+
+            # Assert
+            assert result is not example_raster
+            assert result.raster_meta is not example_raster.raster_meta
+
+        def test_preserves_cell_size(self, example_raster: Raster) -> None:
+            # Act
+            result = example_raster.set_origin(x=100.0, y=200.0)
+
+            # Assert
+            assert result.cell_size == example_raster.cell_size
+
+        def test_longitude_wrapping_use_case(self) -> None:
+            # Arrange - raster with non-standard longitude
+            meta = RasterMeta(
+                crs=CRS.from_epsg(4326),
+                transform=Affine(1.0, 0.0, -200.0, 0.0, -1.0, -30.0),
+            )
+            raster = Raster(arr=np.ones((30, 30)), raster_meta=meta)
+
+            # Act
+            result = raster.set_origin(x=raster.origin[0] + 360)
+
+            # Assert
+            assert result.origin[0] == pytest.approx(160.0)
+            assert result.bounds.xmin == pytest.approx(160.0)
+            assert np.array_equal(result.arr, raster.arr)
 
     class TestApply:
         def test_sine(self, example_raster: Raster):


### PR DESCRIPTION
## Summary

Adds `Raster.origin` property (getter + setter) and `Raster.set_origin(*, x=None, y=None)` immutable method to adjust the affine transform origin without modifying pixel data.

## Motivation

When working with ShakeMap rasters near the antimeridian, some source rasters arrive with non-standard longitude conventions (e.g. bounds from -200 to -170). This causes spatial operations like `to_bounds()` to produce all-NaN output due to no overlap with standard EPSG:4326 bounds.

## Usage

```python
# Fix non-standard longitude
if raster.bounds.xmin < -180:
    raster = raster.set_origin(x=raster.origin[0] + 360)
```

## Changes

- `Raster.origin` property (getter): returns `(transform.c, transform.f)`
- `Raster.origin` setter: mutates transform translation in place (notebook/interactive use)
- `Raster.set_origin(*, x=None, y=None)`: returns new Raster with updated origin (pipeline use)
- 11 tests covering getter, setter, immutability, and the longitude wrapping use case
- Design spec at `docs/specs/2025-05-20-set-origin-design.md`

Closes #442
